### PR TITLE
feat: implement backend tax engine and state-based happiness accrual

### DIFF
--- a/src/main/java/com/keves/dreamreach/config/GameEconomyConfig.java
+++ b/src/main/java/com/keves/dreamreach/config/GameEconomyConfig.java
@@ -39,6 +39,18 @@ public class GameEconomyConfig {
     private int peasantJoinThreshold = 75;
     private int peasantLeaveThreshold = 25;
 
+    // --- TAXES & HAPPINESS ---
+    private double taxRateLowMultiplier = 0.5;
+    private double taxRateNormalMultiplier = 1.0;
+    private double taxRateHighMultiplier = 1.5;
+
+    private int happinessModifierLowTax = 2;
+    private int happinessModifierNormalTax = 0;
+    private int happinessModifierHighTax = -5;
+
+    private int taxGoldPerCitizenPerHour = 2;
+    private int taxCooldownMinutes = 60;
+
     // --- CONSUMPTION RATES (Per Hour) ---
     private int foodConsumedPerPeasant = 2;
 

--- a/src/main/java/com/keves/dreamreach/controller/PlayerController.java
+++ b/src/main/java/com/keves/dreamreach/controller/PlayerController.java
@@ -1,6 +1,7 @@
 package com.keves.dreamreach.controller;
 
 import com.keves.dreamreach.config.GameEconomyConfig;
+import com.keves.dreamreach.dto.BuildingConfigResponse;
 import com.keves.dreamreach.dto.ConstructionTaskResponse;
 import com.keves.dreamreach.dto.PlayerProfileResponse;
 import com.keves.dreamreach.dto.TrainingTaskResponse;
@@ -119,6 +120,25 @@ public class PlayerController {
                         .trainTimeSeconds(economyConfig.getTrainTimeBakerSeconds()).build()
         );
 
+        List<BuildingConfigResponse> buildingConfigs = List.of(
+                BuildingConfigResponse.builder().buildingType("house")
+                        .woodCost(economyConfig.getCostHouseWood())
+                        .stoneCost(economyConfig.getCostHouseStone())
+                        .buildTimeSeconds(economyConfig.getBuildTimeHouse()).build(),
+                BuildingConfigResponse.builder().buildingType("bakery")
+                        .woodCost(economyConfig.getCostBakeryWood())
+                        .stoneCost(economyConfig.getCostBakeryStone())
+                        .buildTimeSeconds(economyConfig.getBuildTimeBakery()).build(),
+                BuildingConfigResponse.builder().buildingType("lodge")
+                        .woodCost(economyConfig.getCostLodgeWood())
+                        .stoneCost(economyConfig.getCostLodgeStone())
+                        .buildTimeSeconds(economyConfig.getBuildTimeLodge()).build(),
+                BuildingConfigResponse.builder().buildingType("tower")
+                        .woodCost(economyConfig.getCostTowerWood())
+                        .stoneCost(economyConfig.getCostTowerStone())
+                        .buildTimeSeconds(economyConfig.getBuildTimeTower()).build()
+        );
+
         PlayerProfileResponse response = PlayerProfileResponse.builder()
                 .email(account.getEmail())
                 .displayName(account.getProfile().getDisplayName())
@@ -156,6 +176,7 @@ public class PlayerController {
                 .activeConstructions(activeTasks)
                 .activeTrainingTasks(activeTrainingTasks)
                 .trainingConfigs(trainingConfigs) // Map it here
+                .buildingConfigs(buildingConfigs)
                 .build();
 
         return ResponseEntity.ok(response);
@@ -233,6 +254,34 @@ public class PlayerController {
             trainingService.completeTraining(account.getProfile(), taskId);
             return ResponseEntity.ok().build();
         } catch (IllegalStateException | IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
+    }
+
+    // --- NEW TAX ENDPOINTS ---
+
+    @PostMapping("/taxes/bracket")
+    public ResponseEntity<?> setTaxBracket(Authentication authentication, @RequestParam String bracket) {
+        PlayerAccount account = accountRepository.findByEmail(authentication.getName())
+                .orElseThrow(() -> new ResourceNotFoundException("Account not found."));
+
+        try {
+            economyService.setTaxBracket(account.getProfile(), bracket);
+            return ResponseEntity.ok().build();
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
+    }
+
+    @PostMapping("/taxes/collect")
+    public ResponseEntity<?> collectTaxes(Authentication authentication) {
+        PlayerAccount account = accountRepository.findByEmail(authentication.getName())
+                .orElseThrow(() -> new ResourceNotFoundException("Account not found."));
+
+        try {
+            economyService.collectTaxes(account.getProfile());
+            return ResponseEntity.ok().build();
+        } catch (IllegalStateException e) {
             return ResponseEntity.badRequest().body(e.getMessage());
         }
     }

--- a/src/main/java/com/keves/dreamreach/entity/PlayerProfile.java
+++ b/src/main/java/com/keves/dreamreach/entity/PlayerProfile.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.UUID;
+import java.time.Instant;
 
 /**
  * This represents the public-facing identity of a player within the game.
@@ -30,6 +31,16 @@ public class PlayerProfile {
 
     @Column(name = "is_personal_pvp_enabled", nullable = false)
     private boolean isPersonalPvpEnabled = false;
+
+    // --- NEW TAX & HAPPINESS FIELDS ---
+    @Column(name = "happiness", nullable = false)
+    private int happiness = 50;
+
+    @Column(name = "tax_bracket", nullable = false, length = 20)
+    private String taxBracket = "NORMAL"; // "LOW", "NORMAL", "HIGH"
+
+    @Column(name = "last_tax_collection_time", nullable = false)
+    private Instant lastTaxCollectionTime = Instant.now();
 
     /**
      * The alliance this player is part of.

--- a/src/main/java/com/keves/dreamreach/service/EconomyService.java
+++ b/src/main/java/com/keves/dreamreach/service/EconomyService.java
@@ -65,9 +65,34 @@ public class EconomyService {
         int woodRate = (pop.getWoodcutters() * economyConfig.getWoodPerWoodcutter()) + economyConfig.getBasePassiveWood();
         int stoneRate = (pop.getStoneworkers() * economyConfig.getStonePerStoneworker()) + economyConfig.getBasePassiveStone();
 
+        // Calculate gold rate based on active tax bracket multiplier
+        double taxMultiplier = switch (profile.getTaxBracket().toUpperCase()) {
+            case "LOW" -> economyConfig.getTaxRateLowMultiplier();
+            case "HIGH" -> economyConfig.getTaxRateHighMultiplier();
+            default -> economyConfig.getTaxRateNormalMultiplier();
+        };
+        int goldRate = (int) (pop.getTotalPopulation() * economyConfig.getTaxGoldPerCitizenPerHour() * taxMultiplier);
+
+        // Apply happiness modifier based on active tax bracket
+        int happinessMod = switch (profile.getTaxBracket().toUpperCase()) {
+            case "LOW" -> economyConfig.getHappinessModifierLowTax();
+            case "HIGH" -> economyConfig.getHappinessModifierHighTax();
+            default -> economyConfig.getHappinessModifierNormalTax();
+        };
+
+        // Calculate accrued happiness over the timeframe elapsed
+        int totalHappinessChange = (int) (happinessMod * hoursElapsed);
+        int newHappiness = profile.getHappiness() + totalHappinessChange;
+
+        // Clamp happiness firmly between 0 and the established maximum cap
+        if (newHappiness > economyConfig.getMaxHappiness()) newHappiness = economyConfig.getMaxHappiness();
+        if (newHappiness < 0) newHappiness = 0;
+        profile.setHappiness(newHappiness);
+
         int newPendingFood = res.getPendingFood() + (int)(foodRate * hoursElapsed);
         int newPendingWood = res.getPendingWood() + (int)(woodRate * hoursElapsed);
         int newPendingStone = res.getPendingStone() + (int)(stoneRate * hoursElapsed);
+        int newPendingGold = res.getPendingGold() + (int)(goldRate * hoursElapsed);
 
         // Clamp pending consumption to prevent total treasury from dropping below zero
         if (res.getFood() + newPendingFood < 0) {
@@ -79,10 +104,14 @@ public class EconomyService {
         if (res.getStone() + newPendingStone < 0) {
             newPendingStone = -res.getStone();
         }
+        if (res.getGold() + newPendingGold < 0) {
+            newPendingGold = -res.getGold();
+        }
 
         res.setPendingFood(newPendingFood);
         res.setPendingWood(newPendingWood);
         res.setPendingStone(newPendingStone);
+        res.setPendingGold(newPendingGold);
 
         res.setLastUpdate(now);
 
@@ -102,13 +131,51 @@ public class EconomyService {
         res.setFood(Math.max(0, res.getFood() + res.getPendingFood()));
         res.setWood(Math.max(0, res.getWood() + res.getPendingWood()));
         res.setStone(Math.max(0, res.getStone() + res.getPendingStone()));
-        res.setGold(Math.max(0, res.getGold() + res.getPendingGold()));
+
+        // Note: Gold is explicitly NOT claimed here anymore. It has a separate 1-hour collection cycle via collectTaxes().
 
         res.setPendingFood(0);
         res.setPendingWood(0);
         res.setPendingStone(0);
+
+        profileRepository.save(profile);
+    }
+
+    /**
+     * Instantly flushes the economy state and updates the active tax bracket.
+     * Prevents players from exploiting the 1-hour collection cycle.
+     */
+    @Transactional
+    public void setTaxBracket(PlayerProfile profile, String bracket) {
+        updateProductionState(profile);
+
+        String upper = bracket.toUpperCase();
+        if (!upper.equals("LOW") && !upper.equals("NORMAL") && !upper.equals("HIGH")) {
+            throw new IllegalArgumentException("Invalid tax bracket.");
+        }
+        profile.setTaxBracket(upper);
+        profileRepository.save(profile);
+    }
+
+    /**
+     * Validates the 1-hour cooldown and moves pending gold into the spendable treasury.
+     */
+    @Transactional
+    public void collectTaxes(PlayerProfile profile) {
+        updateProductionState(profile);
+
+        Instant now = Instant.now();
+        double minutesElapsed = Duration.between(profile.getLastTaxCollectionTime(), now).toMinutes();
+
+        if (minutesElapsed < economyConfig.getTaxCooldownMinutes()) {
+            throw new IllegalStateException("Tax collection is on cooldown.");
+        }
+
+        PlayerResources res = profile.getResources();
+        res.setGold(Math.max(0, res.getGold() + res.getPendingGold()));
         res.setPendingGold(0);
 
+        profile.setLastTaxCollectionTime(now);
         profileRepository.save(profile);
     }
 }

--- a/src/main/resources/db/migration/V11__Add_Tax_And_Happiness.sql
+++ b/src/main/resources/db/migration/V11__Add_Tax_And_Happiness.sql
@@ -1,0 +1,5 @@
+-- V11: Add Happiness, Tax Bracket, and Last Tax Collection Time to Player Profile
+ALTER TABLE player_profile
+    ADD COLUMN happiness INTEGER NOT NULL DEFAULT 50,
+ADD COLUMN tax_bracket VARCHAR(20) NOT NULL DEFAULT 'NORMAL',
+ADD COLUMN last_tax_collection_time TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP;


### PR DESCRIPTION
- Added 'happiness', 'tax_bracket', and 'last_tax_collection_time' to 'PlayerProfile' (Flyway V11).
- Updated 'GameEconomyConfig' with tax multiplier and happiness modifier balancing variables.
- Refactored 'EconomyService.updateProductionState' to calculate pending gold and kingdom happiness dynamically based on elapsed time and active tax bracket.
- Created '/taxes/bracket' endpoint to flush state and switch tax policies securely.
- Created '/taxes/collect' endpoint with a strict 1-hour cooldown validation.