### PR TITLE
feat: implement RNG population simulation and emigration cascade

### DIFF
--- a/src/main/java/com/keves/dreamreach/config/GameEconomyConfig.java
+++ b/src/main/java/com/keves/dreamreach/config/GameEconomyConfig.java
@@ -36,8 +36,14 @@ public class GameEconomyConfig {
     private int basePeasantCap = 10;
     private int capacityPerHouse = 5;
     private int maxHappiness = 100;
-    private int peasantJoinThreshold = 75;
-    private int peasantLeaveThreshold = 25;
+
+    // --- RNG POPULATION SIMULATION ---
+    private int popTickIntervalMinutes = 15;
+    private double baseMovementChance = 0.50;
+    private double baseJoinWeight = 0.66;
+    private double popChangePercentMin = 0.03;
+    private double popChangePercentMax = 0.05;
+    private double happinessImpactMultiplier = 0.01;
 
     // --- TAXES & HAPPINESS ---
     private double taxRateLowMultiplier = 0.5;
@@ -78,7 +84,7 @@ public class GameEconomyConfig {
     private int buildTimeTower = 300;
     private int buildTimeLodge = 300;    // 5 mins
 
-// --- TRAINING COSTS & TIMERS ---
+    // --- TRAINING COSTS & TIMERS ---
     // Granular balancing for each profession type
 
     // Woodcutter

--- a/src/main/java/com/keves/dreamreach/entity/PlayerPopulation.java
+++ b/src/main/java/com/keves/dreamreach/entity/PlayerPopulation.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import java.util.UUID;
+import java.time.Instant;
 
 @Entity
 @Getter
@@ -19,7 +20,11 @@ public class PlayerPopulation {
     @Column(nullable = false) private int hunters = 0;
     @Column(nullable = false) private int woodcutters = 0;
     @Column(nullable = false) private int stoneworkers = 0;
-    @Column(nullable = false) private int bakers = 0; // The new profession
+    @Column(nullable = false) private int bakers = 0;
+
+    // Tracks the last time the 15-minute RNG loop evaluated this population
+    @Column(name = "last_population_tick", nullable = false)
+    private Instant lastPopulationTick = Instant.now();
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "profile_id", nullable = false, unique = true)

--- a/src/main/java/com/keves/dreamreach/service/EconomyService.java
+++ b/src/main/java/com/keves/dreamreach/service/EconomyService.java
@@ -95,27 +95,129 @@ public class EconomyService {
         int newPendingGold = res.getPendingGold() + (int)(goldRate * hoursElapsed);
 
         // Clamp pending consumption to prevent total treasury from dropping below zero
-        if (res.getFood() + newPendingFood < 0) {
-            newPendingFood = -res.getFood();
-        }
-        if (res.getWood() + newPendingWood < 0) {
-            newPendingWood = -res.getWood();
-        }
-        if (res.getStone() + newPendingStone < 0) {
-            newPendingStone = -res.getStone();
-        }
-        if (res.getGold() + newPendingGold < 0) {
-            newPendingGold = -res.getGold();
-        }
+        if (res.getFood() + newPendingFood < 0) newPendingFood = -res.getFood();
+        if (res.getWood() + newPendingWood < 0) newPendingWood = -res.getWood();
+        if (res.getStone() + newPendingStone < 0) newPendingStone = -res.getStone();
+        if (res.getGold() + newPendingGold < 0) newPendingGold = -res.getGold();
 
         res.setPendingFood(newPendingFood);
         res.setPendingWood(newPendingWood);
         res.setPendingStone(newPendingStone);
         res.setPendingGold(newPendingGold);
-
         res.setLastUpdate(now);
 
+        // --- RNG POPULATION SIMULATION LOOP ---
+        Instant lastPopTick = pop.getLastPopulationTick();
+        if (lastPopTick == null) {
+            lastPopTick = now;
+            pop.setLastPopulationTick(now);
+        }
+
+        long minutesSincePopTick = Duration.between(lastPopTick, now).toMinutes();
+        int ticksPassed = (int) (minutesSincePopTick / economyConfig.getPopTickIntervalMinutes());
+
+        if (ticksPassed > 0) {
+            int currentHappiness = profile.getHappiness();
+
+            int houseCount = (int) profile.getBuildings().stream()
+                    .filter(b -> b.getBuildingType().equalsIgnoreCase("house")).count();
+            int maxPop = houseCount * economyConfig.getCapacityPerHouse();
+
+            // Run the RNG evaluation exactly as many times as the 15-minute interval passed
+            for (int i = 0; i < ticksPassed; i++) {
+                int currentPop = pop.getTotalPopulation();
+
+                // Happiness scales the likelihood of joining vs leaving
+                double joinWeightMod = (currentHappiness - 50) * economyConfig.getHappinessImpactMultiplier();
+                double effectiveJoinWeight = Math.max(0.0, Math.min(1.0, economyConfig.getBaseJoinWeight() + joinWeightMod));
+
+                // Extreme happiness (very high or very low) increases overall activity
+                double movementMod = Math.abs(currentHappiness - 50) * (economyConfig.getHappinessImpactMultiplier() / 2.0);
+                double effectiveMovementChance = Math.max(0.0, Math.min(1.0, economyConfig.getBaseMovementChance() + movementMod));
+
+                if (Math.random() < effectiveMovementChance) {
+                    double pct = economyConfig.getPopChangePercentMin() + Math.random() * (economyConfig.getPopChangePercentMax() - economyConfig.getPopChangePercentMin());
+                    int changeAmount = (int) Math.ceil(currentPop * pct);
+
+                    if (Math.random() < effectiveJoinWeight) {
+                        // Immigration: Idle peasants arrive up to the housing cap
+                        int spaceLeft = maxPop - currentPop;
+                        int actuallyJoining = Math.min(changeAmount, spaceLeft);
+                        if (actuallyJoining > 0) {
+                            pop.setIdlePeasants(pop.getIdlePeasants() + actuallyJoining);
+                        }
+                    } else {
+                        // Emigration: People leave, restricted by the hard soft-lock floor
+                        int actuallyLeaving = Math.min(changeAmount, currentPop - economyConfig.getStartingPeasants());
+                        if (actuallyLeaving > 0) {
+                            processEmigrationCascade(profile, pop, actuallyLeaving);
+                        }
+                    }
+                }
+            }
+
+            // Fast forward the tick tracker so we don't double-count next time
+            pop.setLastPopulationTick(lastPopTick.plus(Duration.ofMinutes((long) ticksPassed * economyConfig.getPopTickIntervalMinutes())));
+        }
+
         profileRepository.save(profile);
+    }
+
+    /**
+     * Handles the structured drain of population when conditions are poor.
+     * Drains idle peasants completely before randomly picking off trained professionals.
+     */
+    private void processEmigrationCascade(PlayerProfile profile, PlayerPopulation pop, int amountToLeave) {
+        int remainingToLeave = amountToLeave;
+
+        // Step 1: The Idle Meat-Shield
+        if (pop.getIdlePeasants() > 0) {
+            int idleDrain = Math.min(pop.getIdlePeasants(), remainingToLeave);
+            pop.setIdlePeasants(pop.getIdlePeasants() - idleDrain);
+            remainingToLeave -= idleDrain;
+        }
+
+        // Step 2 & 3: The Professional Drain & Random Walkout
+        while (remainingToLeave > 0) {
+            java.util.List<String> availableProfessions = new java.util.ArrayList<>();
+            if (pop.getBakers() > 0) availableProfessions.add("baker");
+            if (pop.getHunters() > 0) availableProfessions.add("hunter");
+            if (pop.getWoodcutters() > 0) availableProfessions.add("woodcutter");
+            if (pop.getStoneworkers() > 0) availableProfessions.add("stoneworker");
+
+            if (availableProfessions.isEmpty()) {
+                break; // Absolute hard stop, no one left to leave
+            }
+
+            // Pick a random specialized profession to deduct
+            String chosenProfession = availableProfessions.get((int) (Math.random() * availableProfessions.size()));
+
+            switch (chosenProfession) {
+                case "baker": pop.setBakers(pop.getBakers() - 1); break;
+                case "hunter": pop.setHunters(pop.getHunters() - 1); break;
+                case "woodcutter": pop.setWoodcutters(pop.getWoodcutters() - 1); break;
+                case "stoneworker": pop.setStoneworkers(pop.getStoneworkers() - 1); break;
+            }
+
+            // Phantom Worker Fix: Remove 1 assigned worker from a physical building instance to keep the economy accurate
+            String buildingType = getBuildingTypeForProfession(chosenProfession);
+            if (buildingType != null) {
+                for (com.keves.dreamreach.entity.BuildingInstance b : profile.getBuildings()) {
+                    if (b.getBuildingType().equalsIgnoreCase(buildingType) && b.getAssignedWorkers() > 0) {
+                        b.setAssignedWorkers(b.getAssignedWorkers() - 1);
+                        break;
+                    }
+                }
+            }
+
+            remainingToLeave--;
+        }
+    }
+
+    private String getBuildingTypeForProfession(String profession) {
+        if ("baker".equalsIgnoreCase(profession)) return "bakery";
+        if ("hunter".equalsIgnoreCase(profession)) return "lodge";
+        return null;
     }
 
     /**

--- a/src/main/resources/db/migration/V12__Add_Last_Population_Tick.sql
+++ b/src/main/resources/db/migration/V12__Add_Last_Population_Tick.sql
@@ -1,0 +1,3 @@
+-- V12: Add Last Population Tick for the 15-minute RNG engine
+ALTER TABLE player_population
+    ADD COLUMN last_population_tick TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP;


### PR DESCRIPTION
- Added 'last_population_tick' to 'PlayerPopulation' schema via Flyway V12.
- Updated 'GameEconomyConfig' with precision RNG controls and removed deprecated static population thresholds.
- Refactored 'EconomyService.updateProductionState' to calculate elapsed 15-minute intervals and run the RNG population loop.
- Implemented 'processEmigrationCascade' to strictly drain idle peasants before picking off specialized professionals.
- Added 'Phantom Worker' fix to automatically decrement 'assignedWorkers' from a 'BuildingInstance' if a professional flees the kingdom.