### PR TITLE
fix: enforce physical lodge assignment for hunter food production

### DIFF
--- a/src/main/java/com/keves/dreamreach/config/GameEconomyConfig.java
+++ b/src/main/java/com/keves/dreamreach/config/GameEconomyConfig.java
@@ -64,7 +64,7 @@ public class GameEconomyConfig {
     private int foodPerHunter = 5;
     private int woodPerWoodcutter = 3;
     private int stonePerStoneworker = 2;
-    private int foodPerBakery = 15;
+    private int foodPerBaker = 15;
 
     // --- BUILDING WORKER CAPACITIES ---
     private int maxWorkersBakery = 2;

--- a/src/main/java/com/keves/dreamreach/controller/PlayerController.java
+++ b/src/main/java/com/keves/dreamreach/controller/PlayerController.java
@@ -132,7 +132,7 @@ public class PlayerController {
                         .stoneCost(economyConfig.getCostBakeryStone())
                         .buildTimeSeconds(economyConfig.getBuildTimeBakery())
                         .maxWorkers(economyConfig.getMaxWorkersBakery())
-                        .productionRate(economyConfig.getFoodPerBakery()).build(),
+                        .productionRate(economyConfig.getFoodPerBaker()).build(),
                 BuildingConfigResponse.builder().buildingType("lodge")
                         .woodCost(economyConfig.getCostLodgeWood())
                         .stoneCost(economyConfig.getCostLodgeStone())

--- a/src/main/java/com/keves/dreamreach/service/EconomyService.java
+++ b/src/main/java/com/keves/dreamreach/service/EconomyService.java
@@ -37,10 +37,16 @@ public class EconomyService {
         // Iterate through physical bakeries and multiply their specific assigned workers by the base rate
         int bakeryProduction = profile.getBuildings().stream()
                 .filter(b -> b.getBuildingType().equalsIgnoreCase("bakery"))
-                .mapToInt(b -> b.getAssignedWorkers() * economyConfig.getFoodPerBakery())
+                .mapToInt(b -> b.getAssignedWorkers() * economyConfig.getFoodPerBaker())
                 .sum();
 
-        int production = (pop.getHunters() * economyConfig.getFoodPerHunter()) + bakeryProduction;
+        // Iterate through physical lodges and multiply their specific assigned workers by the base rate
+        int lodgeProduction = profile.getBuildings().stream()
+                .filter(b -> b.getBuildingType().equalsIgnoreCase("lodge"))
+                .mapToInt(b -> b.getAssignedWorkers() * economyConfig.getFoodPerHunter())
+                .sum();
+
+        int production = lodgeProduction + bakeryProduction;
 
         int consumption = pop.getTotalPopulation() * economyConfig.getFoodConsumedPerPeasant();
 


### PR DESCRIPTION
- Updated 'EconomyService.calculateFoodRate' to iterate through 'lodge' BuildingInstances and multiply assigned workers by 'foodPerHunter'.
- Removed previous flawed logic that generated food passively based on the raw total count of trained hunters.