### PR TITLE
feat: implement split-pane Heroes view and D&D character sheet

### DIFF
--- a/dreamreach-ui/src/components/Icon.tsx
+++ b/dreamreach-ui/src/components/Icon.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 interface IconProps {
-    name: 'population' | 'food' | 'wood' | 'stone' | 'gold' | 'gems' | 'logout' | 'home' | 'combat' | 'summon' | 'kingdom';
+    name: 'population' | 'food' | 'wood' | 'stone' | 'gold' | 'gems' | 'logout' | 'home' | 'combat' | 'summon' | 'kingdom' | 'filter' | 'inventory' | 'plus' | 'user' | 'health';
     size?: number;
     className?: string;
     style?: React.CSSProperties;
@@ -18,7 +18,12 @@ const paths = {
     kingdom: "M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4z",
     combat: "M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4z",
     summon: "M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z",
-    logout: "M17 7l-1.41 1.41L18.17 11H8v2h10.17l-2.58 2.58L17 17l5-5-5-5zM4 5h8V3H4c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h8v-2H4V5z"
+    logout: "M17 7l-1.41 1.41L18.17 11H8v2h10.17l-2.58 2.58L17 17l5-5-5-5zM4 5h8V3H4c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h8v-2H4V5z",
+    filter: "M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z",
+    inventory: "M20 6h-4V4c0-1.11-.89-2-2-2h-4c-1.11 0-2 .89-2 2v2H4c-1.11 0-1.99.89-1.99 2L2 19c0 1.11.89 2 2 2h16c1.11 0 2-.89 2-2V8c0-1.11-.89-2-2-2zm-8 0h-4V4h4v2z",
+    plus: "M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z",
+    user: "M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z",
+    health: "M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"
 };
 
 export const Icon: React.FC<IconProps> = ({ name, size = 20, className, style }) => {

--- a/dreamreach-ui/src/views/HeroesView.css
+++ b/dreamreach-ui/src/views/HeroesView.css
@@ -1,154 +1,186 @@
-.heroes-container {
+.heroes-split-layout {
     display: flex;
-    flex-direction: column;
-    gap: var(--space-lg);
-    height: 100%;
+    height: calc(100vh - 80px);
+    gap: var(--space-md);
 }
 
-.heroes-header {
+/* Deck Pane */
+.heroes-deck-pane {
+    width: 320px;
     display: flex;
-    justify-content: space-between;
-    align-items: center;
+    flex-direction: column;
     background: var(--bg-panel);
-    padding: var(--space-lg);
+    border: 1px solid var(--border-strong);
     border-radius: 8px;
-    border: 1px solid var(--border-strong);
-    box-shadow: 0 4px 12px rgba(0,0,0,0.2);
-}
-
-.heroes-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-    gap: var(--space-xl);
-    padding-bottom: var(--space-xl);
-}
-
-.hero-card {
-    background: var(--bg-panel);
-    border-radius: 12px;
-    border: 2px solid var(--border-subtle);
-    overflow: hidden;
-    display: flex;
-    flex-direction: column;
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
-    position: relative;
-}
-
-.hero-card:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.6);
-}
-
-.hero-card-header {
-    display: flex;
-    justify-content: space-between;
-    padding: 12px;
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    z-index: 2;
-}
-
-.hero-rarity-badge {
-    color: #fff;
-    font-size: 0.7rem;
-    font-weight: bold;
-    padding: 4px 8px;
-    border-radius: 4px;
-    text-transform: uppercase;
-    text-shadow: 0 1px 2px rgba(0,0,0,0.8);
-    box-shadow: 0 2px 4px rgba(0,0,0,0.5);
-}
-
-.hero-status-badge {
-    background: rgba(0,0,0,0.7);
-    color: var(--text-primary);
-    font-size: 0.7rem;
-    font-weight: bold;
-    padding: 4px 8px;
-    border-radius: 4px;
-    border: 1px solid var(--border-strong);
-}
-
-.hero-portrait-container {
-    height: 180px;
-    background: var(--surface-1);
-    border-bottom: 2px solid;
-    position: relative;
     overflow: hidden;
 }
 
-.hero-portrait {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    object-position: center top;
-    opacity: 0.9;
-}
-
-.hero-card:hover .hero-portrait {
-    opacity: 1;
-}
-
-.hero-info {
-    padding: 16px;
-    text-align: center;
+.deck-header {
+    padding: var(--space-md);
     border-bottom: 1px solid var(--border-subtle);
 }
 
-.hero-name {
-    margin: 0 0 4px 0;
-    font-family: var(--font-heading);
-    color: var(--text-primary);
-    font-size: 1.2rem;
+.deck-header h2 {
+    margin: 0 0 var(--space-sm) 0;
+    color: var(--accent-gold);
 }
 
-.hero-class {
-    color: var(--text-muted);
-    font-size: 0.85rem;
-    text-transform: uppercase;
-    letter-spacing: 1px;
+.deck-filters {
+    display: flex;
+    gap: 8px;
 }
 
-.hero-vitals {
-    padding: 16px;
+.filter-input {
+    flex: 1;
     background: var(--surface-1);
-    border-bottom: 1px solid var(--border-strong);
+    border: 1px solid var(--border-subtle);
+    border-radius: 4px;
+    padding: 4px 12px;
+    color: var(--text-primary);
+    font-size: 0.85rem;
 }
 
-.hero-stats-grid {
+.deck-list {
+    flex: 1;
+    overflow-y: auto;
+    padding: var(--space-sm);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+}
+
+.deck-item {
+    display: flex;
+    align-items: center;
+    gap: var(--space-md);
+    padding: var(--space-sm);
+    background: var(--surface-1);
+    border: 1px solid var(--border-subtle);
+    border-radius: 6px;
+    cursor: pointer;
+    transition: all 0.2s;
+    position: relative;
+}
+
+.deck-item:hover {
+    border-color: var(--border-strong);
+    transform: translateX(4px);
+}
+
+.deck-item.selected {
+    background: var(--surface-2);
+    border-left: 4px solid var(--accent-gold);
+}
+
+.deck-item-portrait {
+    width: 50px;
+    height: 50px;
+    border-radius: 4px;
+    object-fit: cover;
+}
+
+.deck-item-name {
+    display: block;
+    font-weight: bold;
+    color: var(--text-primary);
+}
+
+.deck-item-class {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+}
+
+/* Parchment Sheet Pane */
+.heroes-sheet-pane {
+    flex: 1;
+    overflow-y: auto;
+    display: flex;
+    justify-content: center;
+    padding: var(--space-md);
+}
+
+.parchment-sheet {
+    background: #fdf6e3;
+    color: #3e2714;
+    width: 100%;
+    max-width: 850px;
+    padding: 40px;
+    border: 2px solid #8b572a;
+    border-radius: 2px;
+    box-shadow: 0 10px 30px rgba(0,0,0,0.5);
+    display: flex;
+    flex-direction: column;
+    gap: 30px;
+}
+
+/* Rarity Accents on Parchment */
+.parchment-sheet.rarity-legendary { border-color: var(--accent-gold); box-shadow: 0 0 20px rgba(255, 179, 0, 0.3); }
+.parchment-sheet.rarity-epic { border-color: #a335ee; }
+.parchment-sheet.rarity-rare { border-color: #0070dd; }
+
+.sheet-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    border-bottom: 2px solid #8b572a;
+    padding-bottom: 20px;
+}
+
+.sheet-header-left { display: flex; gap: 20px; }
+
+.sheet-portrait {
+    width: 100px;
+    height: 100px;
+    border: 3px solid #8b572a;
+    border-radius: 4px;
+    object-fit: cover;
+}
+
+.sheet-header-text h1 { margin: 0; font-family: serif; font-size: 2.5rem; }
+
+.sheet-subtitle { font-weight: bold; text-transform: uppercase; font-size: 0.9rem; display: flex; gap: 15px; margin-top: 5px; }
+
+.sheet-vitals-container { width: 180px; }
+
+.sheet-hp-display { display: flex; justify-content: space-between; font-weight: bold; margin-bottom: 5px; }
+
+.sheet-stats-block {
+    background: rgba(139, 87, 42, 0.05);
+    padding: 15px;
+    border: 1px solid #8b572a;
+}
+
+.section-title {
+    font-family: serif;
+    border-bottom: 1px solid #8b572a;
+    margin-bottom: 15px;
+    padding-bottom: 5px;
+    display: flex;
+    align-items: center;
+}
+
+.stats-grid {
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 1px;
-    background: var(--border-strong);
-    padding: 1px;
+    grid-template-columns: repeat(6, 1fr);
+    gap: 15px;
 }
 
-.hero-stat-box {
-    background: var(--bg-panel);
+.stat-box {
+    background: white;
+    border: 2px solid #8b572a;
+    border-radius: 8px;
     display: flex;
     flex-direction: column;
     align-items: center;
-    padding: 8px 4px;
+    padding: 10px 0;
 }
 
-.stat-label {
-    font-size: 0.65rem;
-    color: var(--text-muted);
-    margin-bottom: 2px;
-}
+.stat-label { font-size: 0.7rem; font-weight: bold; }
+.stat-mod { font-size: 1.8rem; font-weight: bold; margin: 2px 0; }
+.stat-score { font-size: 0.8rem; background: #eee; padding: 2px 8px; border-radius: 10px; }
 
-.stat-mod {
-    font-size: 1.1rem;
-    font-family: var(--font-heading);
-    color: var(--text-primary);
-    font-weight: bold;
-}
+.equipment-summary { display: flex; font-weight: bold; }
 
-.stat-val {
-    font-size: 0.7rem;
-    color: var(--text-secondary);
-    margin-top: 2px;
-}
+.placeholder-text { font-style: italic; color: #666; }
+
+.sheet-empty-state { display: flex; flex-direction: column; align-items: center; justify-content: center; color: var(--text-muted); text-align: center; }

--- a/dreamreach-ui/src/views/HeroesView.tsx
+++ b/dreamreach-ui/src/views/HeroesView.tsx
@@ -1,5 +1,6 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import api from '../api/client';
+import { Icon } from '../components/Icon';
 import './HeroesView.css';
 
 interface Character {
@@ -33,119 +34,148 @@ interface Character {
 export default function HeroesView() {
     const [roster, setRoster] = useState<Character[]>([]);
     const [loading, setLoading] = useState(true);
+    const [selectedCharacterId, setSelectedCharacterId] = useState<string | null>(null);
 
     useEffect(() => {
         api.get('/roster')
             .then(res => {
                 setRoster(res.data);
+                if (res.data.length > 0 && !selectedCharacterId) {
+                    setSelectedCharacterId(res.data[0].characterId);
+                }
                 setLoading(false);
             })
             .catch(err => {
                 console.error("Failed to load roster", err);
                 setLoading(false);
             });
-    }, []);
+    }, [selectedCharacterId]);
 
     const formatMod = (mod: number) => mod >= 0 ? `+${mod}` : `${mod}`;
 
-    // Dynamic styling based on the actual Gacha Tier
-    const getRarityColor = (rarity: string) => {
+    const getRarityClass = (rarity: string) => {
         switch(rarity.toUpperCase()) {
-            case 'LEGENDARY': return 'var(--accent-gold)';
-            case 'EPIC': return '#a335ee';
-            case 'RARE': return '#0070dd';
-            case 'UNCOMMON': return '#1eff00';
-            default: return 'var(--border-subtle)';
+            case 'LEGENDARY': return 'rarity-legendary';
+            case 'EPIC': return 'rarity-epic';
+            case 'RARE': return 'rarity-rare';
+            case 'UNCOMMON': return 'rarity-uncommon';
+            default: return 'rarity-common';
         }
     };
+
+    const selectedCharacter = useMemo(() => {
+        if (!selectedCharacterId) return null;
+        return roster.find(char => char.characterId === selectedCharacterId) || null;
+    }, [roster, selectedCharacterId]);
 
     if (loading) return <div className="panel" style={{ margin: 'var(--space-md)' }}>Gathering Party...</div>;
 
     return (
-        <div className="heroes-container">
-            <div className="heroes-header">
-                <h2 style={{ color: 'var(--accent-gold)', margin: 0 }}>Your Heroes</h2>
-                <span style={{ color: 'var(--text-muted)' }}>{roster.length} Active Characters</span>
-            </div>
-
-            {roster.length === 0 ? (
-                <div className="panel" style={{ textAlign: 'center', padding: '40px' }}>
-                    <p style={{ color: 'var(--text-secondary)' }}>You haven't summoned any heroes yet.</p>
+        <div className="heroes-split-layout">
+            {/* Left: Scrollable Deck List */}
+            <aside className="heroes-deck-pane">
+                <div className="deck-header">
+                    <h2>Roster</h2>
+                    <div className="deck-filters">
+                        <input type="text" placeholder="Filter Heroes..." className="filter-input" />
+                        <button className="button--secondary"><Icon name="filter" size={16} /></button>
+                    </div>
                 </div>
-            ) : (
-                <div className="heroes-grid">
-                    {roster.map(char => (
-                        <div key={char.characterId} className="hero-card" style={{ borderColor: getRarityColor(char.rarity) }}>
-                            <div className="hero-card-header">
-                                <div className="hero-rarity-badge" style={{ backgroundColor: getRarityColor(char.rarity) }}>
-                                    {char.rarity}
+
+                {roster.length === 0 ? (
+                    <div className="deck-empty-state">
+                        <Icon name="user" size={32} />
+                        <p>No heroes recruited.</p>
+                    </div>
+                ) : (
+                    <div className="deck-list">
+                        {roster.map(char => (
+                            <div
+                                key={char.characterId}
+                                className={`deck-item ${selectedCharacterId === char.characterId ? 'selected' : ''} ${getRarityClass(char.rarity)}`}
+                                onClick={() => setSelectedCharacterId(char.characterId)}
+                            >
+                                <img src={char.portraitUrl || '/assets/hero.png'} alt={char.name} className="deck-item-portrait" />
+                                <div className="deck-item-info">
+                                    <span className="deck-item-name">{char.name}</span>
+                                    <span className="deck-item-class">Level {char.level} {char.dndClass}</span>
                                 </div>
-                                <div className="hero-status-badge">{char.status}</div>
+                                <div className="deck-item-rarity-badge"></div>
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </aside>
+
+            {/* Right: Detailed D&D Character Sheet */}
+            <main className="heroes-sheet-pane">
+                {selectedCharacter ? (
+                    <div className={`parchment-sheet ${getRarityClass(selectedCharacter.rarity)}`}>
+                        <header className="sheet-header">
+                            <div className="sheet-header-left">
+                                <img src={selectedCharacter.portraitUrl || '/assets/hero.png'} alt={selectedCharacter.name} className="sheet-portrait" />
+                                <div className="sheet-header-text">
+                                    <h1>{selectedCharacter.name}</h1>
+                                    <div className="sheet-subtitle">
+                                        <span className="sheet-rarity">{selectedCharacter.rarity}</span>
+                                        <span className="sheet-class-level">Lv.{selectedCharacter.level} {selectedCharacter.dndClass}</span>
+                                    </div>
+                                    <div className="sheet-status">Status: {selectedCharacter.status}</div>
+                                </div>
                             </div>
 
-                            <div className="hero-portrait-container" style={{ borderColor: getRarityColor(char.rarity) }}>
-                                <img src={char.portraitUrl || '/assets/hero.png'} alt={char.name} className="hero-portrait" />
-                            </div>
-
-                            <div className="hero-info">
-                                <h3 className="hero-name">{char.name}</h3>
-                                <div className="hero-class">Level {char.level} {char.dndClass}</div>
-                            </div>
-
-                            <div className="hero-vitals">
-                                <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '0.8rem', marginBottom: '4px' }}>
+                            <div className="sheet-vitals-container">
+                                <div className="sheet-hp-display">
                                     <span>HP</span>
-                                    <span style={{ color: char.currentHp > 0 ? 'var(--success)' : 'var(--danger)' }}>
-                                        {char.currentHp} / {char.maxHp}
-                                    </span>
+                                    <span className="hp-vals">{selectedCharacter.currentHp} / {selectedCharacter.maxHp}</span>
                                 </div>
                                 <div className="progress-bar-container">
-                                    <div
-                                        className="progress-bar-fill"
-                                        style={{
-                                            width: `${(char.currentHp / char.maxHp) * 100}%`,
-                                            backgroundColor: char.currentHp > 0 ? 'var(--success)' : 'var(--danger)'
-                                        }}
-                                    ></div>
+                                    <div className="progress-bar-fill success" style={{ width: `${(selectedCharacter.currentHp / selectedCharacter.maxHp) * 100}%` }}></div>
                                 </div>
                             </div>
+                        </header>
 
-                            <div className="hero-stats-grid">
-                                <div className="hero-stat-box">
-                                    <span className="stat-label">STR</span>
-                                    <span className="stat-mod">{formatMod(char.strMod)}</span>
-                                    <span className="stat-val">{char.totalStrength}</span>
-                                </div>
-                                <div className="hero-stat-box">
-                                    <span className="stat-label">DEX</span>
-                                    <span className="stat-mod">{formatMod(char.dexMod)}</span>
-                                    <span className="stat-val">{char.totalDexterity}</span>
-                                </div>
-                                <div className="hero-stat-box">
-                                    <span className="stat-label">CON</span>
-                                    <span className="stat-mod">{formatMod(char.conMod)}</span>
-                                    <span className="stat-val">{char.totalConstitution}</span>
-                                </div>
-                                <div className="hero-stat-box">
-                                    <span className="stat-label">INT</span>
-                                    <span className="stat-mod">{formatMod(char.intMod)}</span>
-                                    <span className="stat-val">{char.totalIntelligence}</span>
-                                </div>
-                                <div className="hero-stat-box">
-                                    <span className="stat-label">WIS</span>
-                                    <span className="stat-mod">{formatMod(char.wisMod)}</span>
-                                    <span className="stat-val">{char.totalWisdom}</span>
-                                </div>
-                                <div className="hero-stat-box">
-                                    <span className="stat-label">CHA</span>
-                                    <span className="stat-mod">{formatMod(char.chaMod)}</span>
-                                    <span className="stat-val">{char.totalCharisma}</span>
-                                </div>
+                        <section className="sheet-stats-block">
+                            <h2 className="section-title">Ability Scores</h2>
+                            <div className="stats-grid">
+                                {[
+                                    {label: 'STR', val: selectedCharacter.totalStrength, mod: selectedCharacter.strMod},
+                                    {label: 'DEX', val: selectedCharacter.totalDexterity, mod: selectedCharacter.dexMod},
+                                    {label: 'CON', val: selectedCharacter.totalConstitution, mod: selectedCharacter.conMod},
+                                    {label: 'INT', val: selectedCharacter.totalIntelligence, mod: selectedCharacter.intMod},
+                                    {label: 'WIS', val: selectedCharacter.totalWisdom, mod: selectedCharacter.wisMod},
+                                    {label: 'CHA', val: selectedCharacter.totalCharisma, mod: selectedCharacter.chaMod}
+                                ].map(stat => (
+                                    <div key={stat.label} className="stat-box">
+                                        <span className="stat-label">{stat.label}</span>
+                                        <span className="stat-mod">{formatMod(stat.mod)}</span>
+                                        <span className="stat-score">{stat.val}</span>
+                                    </div>
+                                ))}
                             </div>
-                        </div>
-                    ))}
-                </div>
-            )}
+                        </section>
+
+                        <section className="sheet-section">
+                            <h2 className="section-title"><Icon name="inventory" size={18} style={{marginRight: '8px'}} /> Inventory</h2>
+                            <div className="equipment-summary">
+                                <div><Icon name="combat" size={16} /> Weapon: {selectedCharacter.weaponTier}</div>
+                                <div style={{marginLeft: '20px'}}><Icon name="kingdom" size={16} /> Armor: {selectedCharacter.armorTier}</div>
+                            </div>
+                        </section>
+
+                        <section className="sheet-section">
+                            <h2 className="section-title"><Icon name="plus" size={18} style={{marginRight: '8px'}} /> Abilities & Powers</h2>
+                            <p className="placeholder-text">Class features and active skills will appear here in future updates.</p>
+                        </section>
+                    </div>
+                ) : (
+                    <div className="sheet-empty-state">
+                        <Icon name="user" size={48} />
+                        <h2>Select a Hero</h2>
+                        <p>Select a hero to view their details.</p>
+                    </div>
+                )}
+            </main>
         </div>
     );
 }

--- a/src/main/java/com/keves/dreamreach/config/GameEconomyConfig.java
+++ b/src/main/java/com/keves/dreamreach/config/GameEconomyConfig.java
@@ -38,8 +38,8 @@ public class GameEconomyConfig {
     private int maxHappiness = 100;
 
     // --- RNG POPULATION SIMULATION ---
-    private int popTickIntervalMinutes = 15;
-    private double baseMovementChance = 0.50;
+    private int popTickIntervalMinutes = 10;
+    private double baseMovementChance = 0.55;
     private double baseJoinWeight = 0.66;
     private double popChangePercentMin = 0.03;
     private double popChangePercentMax = 0.05;


### PR DESCRIPTION
- Refactored 'HeroesView.tsx' from a grid layout to a professional split-pane interface.
- Implemented a vertically scrollable deck list on the left with rarity-based glowing selection borders.
- Developed a detailed, parchment-styled character sheet on the right to display D&D 2024 stat blocks, vitals, and equipment.
- Expanded 'Icon.tsx' with 'filter', 'inventory', 'plus', 'user', and 'health' SVG paths without modifying existing icon logic.
- Optimized character selection with 'useMemo' for real-time sheet updates.