### PR TITLE
fix: resolve IDE warnings and wire up offline catch-up logic

### DIFF
--- a/src/main/java/com/keves/dreamreach/config/GameEconomyConfig.java
+++ b/src/main/java/com/keves/dreamreach/config/GameEconomyConfig.java
@@ -38,8 +38,8 @@ public class GameEconomyConfig {
     private int maxHappiness = 100;
 
     // --- RNG POPULATION SIMULATION ---
-    private int popTickIntervalMinutes = 10;
-    private double baseMovementChance = 0.55;
+    private int popTickIntervalMinutes = 15;
+    private double baseMovementChance = 0.50;
     private double baseJoinWeight = 0.66;
     private double popChangePercentMin = 0.03;
     private double popChangePercentMax = 0.05;
@@ -82,11 +82,38 @@ public class GameEconomyConfig {
     private int costTowerWood = 100;
     private int costTowerStone = 100;
 
+    // The base construction cost for the Tavern
+    private int costTavernWood = 200;
+    private int costTavernStone = 150;
+
     // --- CONSTRUCTION BASE TIMERS (in seconds) ---
     private int buildTimeHouse = 60;     // 1 min
     private int buildTimeBakery = 300;   // 5 mins
     private int buildTimeTower = 300;
     private int buildTimeLodge = 300;    // 5 mins
+
+    // The base construction time for the Tavern
+    private int buildTimeTavern = 600;   // 10 mins
+
+    // --- TAVERN RECRUITMENT LOGIC ---
+    // The required Keep Level to construct or access the Tavern
+    private int tavernUnlockLevel = 5;
+
+    // How often (in minutes) the server calculates if a hero arrived
+    private int tavernCheckIntervalMinutes = 60;
+
+    // The percentage chance (0.0 to 1.0) per interval that an empty slot gets a hero
+    private double tavernArrivalChance = 0.15;
+
+    // How long (in hours) a hero will wait in the Tavern before leaving
+    private int tavernStayDurationHours = 48;
+
+    // Post-purchase Gacha Rarity Weights (e.g. 0.50 = 50% chance for Common)
+    private double rarityWeightCommon = 0.50;
+    private double rarityWeightUncommon = 0.30;
+    private double rarityWeightRare = 0.14;
+    private double rarityWeightEpic = 0.05;
+    private double rarityWeightLegendary = 0.01;
 
     // --- TRAINING COSTS & TIMERS ---
     // Granular balancing for each profession type

--- a/src/main/java/com/keves/dreamreach/controller/PlayerController.java
+++ b/src/main/java/com/keves/dreamreach/controller/PlayerController.java
@@ -12,6 +12,7 @@ import com.keves.dreamreach.repository.TrainingTaskRepository;
 import com.keves.dreamreach.service.ConstructionService;
 import com.keves.dreamreach.service.EconomyService;
 import com.keves.dreamreach.service.RewardService;
+import com.keves.dreamreach.service.TavernService;
 import com.keves.dreamreach.service.TrainingService;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -37,6 +38,7 @@ public class PlayerController {
     private final ConstructionTaskRepository constructionTaskRepository;
     private final TrainingService trainingService;
     private final TrainingTaskRepository trainingTaskRepository;
+    private final TavernService tavernService;
 
     public PlayerController(PlayerAccountRepository accountRepository,
                             GameEconomyConfig economyConfig,
@@ -45,7 +47,8 @@ public class PlayerController {
                             ConstructionService constructionService,
                             ConstructionTaskRepository constructionTaskRepository,
                             TrainingService trainingService,
-                            TrainingTaskRepository trainingTaskRepository) {
+                            TrainingTaskRepository trainingTaskRepository,
+                            TavernService tavernService) {
         this.accountRepository = accountRepository;
         this.economyConfig = economyConfig;
         this.rewardService = rewardService;
@@ -54,6 +57,7 @@ public class PlayerController {
         this.constructionTaskRepository = constructionTaskRepository;
         this.trainingService = trainingService;
         this.trainingTaskRepository = trainingTaskRepository;
+        this.tavernService = tavernService;
     }
 
     @GetMapping("/me")
@@ -65,7 +69,9 @@ public class PlayerController {
 
         PlayerProfile profile = account.getProfile();
 
+        // Run the "lazy checks" to process offline time for the economy and the Tavern
         economyService.updateProductionState(profile);
+        tavernService.processArrivals(profile);
 
         PlayerPopulation pop = profile.getPopulation();
 

--- a/src/main/java/com/keves/dreamreach/entity/CharacterTemplate.java
+++ b/src/main/java/com/keves/dreamreach/entity/CharacterTemplate.java
@@ -77,4 +77,11 @@ public class CharacterTemplate {
 
     @Column(name = "portrait_url")
     private String portraitUrl;
+
+    // --- TAVERN BASE COSTS ---
+    @Column(name = "base_gold_cost", nullable = false)
+    private int baseGoldCost = 500;
+
+    @Column(name = "base_gem_cost", nullable = false)
+    private int baseGemCost = 50;
 }

--- a/src/main/java/com/keves/dreamreach/entity/PlayerProfile.java
+++ b/src/main/java/com/keves/dreamreach/entity/PlayerProfile.java
@@ -42,6 +42,10 @@ public class PlayerProfile {
     @Column(name = "last_tax_collection_time", nullable = false)
     private Instant lastTaxCollectionTime = Instant.now();
 
+    // --- TAVERN CHECK TRACKING ---
+    @Column(name = "last_tavern_check_time")
+    private Instant lastTavernCheckTime = Instant.now();
+
     /**
      * The alliance this player is part of.
      * Using FetchType.LAZY makes it so we don't load the

--- a/src/main/java/com/keves/dreamreach/entity/RecruitmentPool.java
+++ b/src/main/java/com/keves/dreamreach/entity/RecruitmentPool.java
@@ -1,0 +1,33 @@
+package com.keves.dreamreach.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "recruitment_pool")
+@Getter
+@Setter
+@NoArgsConstructor
+public class RecruitmentPool {
+
+    @Id
+    @Column(name = "id", updatable = false, nullable = false)
+    private UUID id = UUID.randomUUID();
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "character_template_id", nullable = false)
+    private CharacterTemplate characterTemplate;
+
+    @Column(name = "weight", nullable = false)
+    private int weight = 10;
+}

--- a/src/main/java/com/keves/dreamreach/entity/TavernListing.java
+++ b/src/main/java/com/keves/dreamreach/entity/TavernListing.java
@@ -1,0 +1,48 @@
+package com.keves.dreamreach.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "tavern_listing")
+@Getter
+@Setter
+@NoArgsConstructor
+public class TavernListing {
+
+    @Id
+    @Column(name = "id", updatable = false, nullable = false)
+    private UUID id = UUID.randomUUID();
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "profile_id", nullable = false, unique = true)
+    private PlayerProfile profile;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "character_template_id", nullable = false)
+    private CharacterTemplate characterTemplate;
+
+    @Column(name = "arrival_time", nullable = false)
+    private Instant arrivalTime;
+
+    @Column(name = "expiry_time", nullable = false)
+    private Instant expiryTime;
+
+    @Column(name = "gold_cost", nullable = false)
+    private int goldCost;
+
+    @Column(name = "gem_cost", nullable = false)
+    private int gemCost;
+}

--- a/src/main/java/com/keves/dreamreach/repository/RecruitmentPoolRepository.java
+++ b/src/main/java/com/keves/dreamreach/repository/RecruitmentPoolRepository.java
@@ -1,0 +1,11 @@
+package com.keves.dreamreach.repository;
+
+import com.keves.dreamreach.entity.RecruitmentPool;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface RecruitmentPoolRepository extends JpaRepository<RecruitmentPool, UUID> {
+}

--- a/src/main/java/com/keves/dreamreach/repository/TavernListingRepository.java
+++ b/src/main/java/com/keves/dreamreach/repository/TavernListingRepository.java
@@ -1,0 +1,13 @@
+package com.keves.dreamreach.repository;
+
+import com.keves.dreamreach.entity.TavernListing;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface TavernListingRepository extends JpaRepository<TavernListing, UUID> {
+    Optional<TavernListing> findByProfileId(UUID profileId);
+}

--- a/src/main/java/com/keves/dreamreach/service/TavernService.java
+++ b/src/main/java/com/keves/dreamreach/service/TavernService.java
@@ -1,0 +1,137 @@
+package com.keves.dreamreach.service;
+
+import com.keves.dreamreach.config.GameEconomyConfig;
+import com.keves.dreamreach.entity.BuildingInstance;
+import com.keves.dreamreach.entity.CharacterTemplate;
+import com.keves.dreamreach.entity.PlayerProfile;
+import com.keves.dreamreach.entity.RecruitmentPool;
+import com.keves.dreamreach.entity.TavernListing;
+import com.keves.dreamreach.repository.PlayerProfileRepository;
+import com.keves.dreamreach.repository.RecruitmentPoolRepository;
+import com.keves.dreamreach.repository.TavernListingRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * Service handling the offline catch-up logic for Tavern hero arrivals.
+ */
+@Service
+public class TavernService {
+
+    private final GameEconomyConfig config;
+    private final PlayerProfileRepository profileRepository;
+    private final TavernListingRepository tavernListingRepository;
+    private final RecruitmentPoolRepository recruitmentPoolRepository;
+    private final Random random = new Random();
+
+    public TavernService(GameEconomyConfig config,
+                         PlayerProfileRepository profileRepository,
+                         TavernListingRepository tavernListingRepository,
+                         RecruitmentPoolRepository recruitmentPoolRepository) {
+        this.config = config;
+        this.profileRepository = profileRepository;
+        this.tavernListingRepository = tavernListingRepository;
+        this.recruitmentPoolRepository = recruitmentPoolRepository;
+    }
+
+    /**
+     * Engine to process organic hero arrivals. Calculates missed intervals
+     * since the player's last check to ensure fairness for offline time.
+     */
+    @Transactional
+    public void processArrivals(PlayerProfile profile) {
+        // Validation: Ensure player has reached the Keep level required for the Tavern
+        int keepLevel = profile.getBuildings().stream()
+                .filter(b -> b.getBuildingType().equalsIgnoreCase("keep"))
+                .mapToInt(BuildingInstance::getLevel)
+                .max().orElse(1);
+
+        if (keepLevel < config.getTavernUnlockLevel()) {
+            return;
+        }
+
+        Instant now = Instant.now();
+        Instant lastCheck = profile.getLastTavernCheckTime();
+        if (lastCheck == null) {
+            lastCheck = now;
+            profile.setLastTavernCheckTime(now);
+        }
+
+        long minutesPassed = Duration.between(lastCheck, now).toMinutes();
+        long intervals = minutesPassed / config.getTavernCheckIntervalMinutes();
+
+        if (intervals <= 0) {
+            return; // Not enough time has passed for a new roll
+        }
+
+        TavernListing currentListing = tavernListingRepository.findByProfileId(profile.getId()).orElse(null);
+        int intervalsProcessed = 0;
+
+        for (int i = 0; i < intervals; i++) {
+            intervalsProcessed++;
+
+            // To simulate time accurately, we calculate the exact moment this roll occurred
+            Instant simulatedTime = lastCheck.plus(Duration.ofMinutes((long) intervalsProcessed * config.getTavernCheckIntervalMinutes()));
+
+            // Check if there is a hero and if they have expired during this simulated step
+            if (currentListing != null) {
+                if (simulatedTime.isAfter(currentListing.getExpiryTime())) {
+                    tavernListingRepository.delete(currentListing);
+                    currentListing = null;
+                } else {
+                    continue; // Slot is full and the hero is still waiting, skip this arrival roll
+                }
+            }
+
+            // Slot is empty, roll for a new arrival
+            if (random.nextDouble() <= config.getTavernArrivalChance()) {
+                generateNewListing(profile, simulatedTime);
+                break; // A hero arrived, stop evaluating further steps
+            }
+        }
+
+        // Advance the check time by the intervals actually processed to save the remaining "unused" minutes
+        profile.setLastTavernCheckTime(lastCheck.plus(Duration.ofMinutes((long) intervalsProcessed * config.getTavernCheckIntervalMinutes())));
+        profileRepository.save(profile);
+    }
+
+    private void generateNewListing(PlayerProfile profile, Instant arrivalTime) {
+        List<RecruitmentPool> pool = recruitmentPoolRepository.findAll();
+        if (pool.isEmpty()) return;
+
+        // Weighted random selection from the roster
+        int totalWeight = pool.stream().mapToInt(RecruitmentPool::getWeight).sum();
+        int roll = random.nextInt(totalWeight);
+
+        RecruitmentPool selected = null;
+        int currentWeight = 0;
+        for (RecruitmentPool p : pool) {
+            currentWeight += p.getWeight();
+            if (roll < currentWeight) {
+                selected = p;
+                break;
+            }
+        }
+
+        if (selected == null) {
+            selected = pool.getLast();
+        }
+
+        CharacterTemplate template = selected.getCharacterTemplate();
+
+        TavernListing listing = new TavernListing();
+        listing.setProfile(profile);
+        listing.setCharacterTemplate(template);
+        listing.setArrivalTime(arrivalTime);
+        listing.setExpiryTime(arrivalTime.plus(Duration.ofHours(config.getTavernStayDurationHours())));
+        listing.setGoldCost(template.getBaseGoldCost());
+        listing.setGemCost(template.getBaseGemCost());
+
+        tavernListingRepository.save(listing);
+    }
+}

--- a/src/main/resources/db/migration/V14__Create_Tavern_System.sql
+++ b/src/main/resources/db/migration/V14__Create_Tavern_System.sql
@@ -1,0 +1,26 @@
+-- Issue 6: Tavern System - Schema, Config & Offline Arrival Engine
+
+-- Add base costs to character_template for Tavern purchasing
+ALTER TABLE character_template ADD COLUMN base_gold_cost INTEGER NOT NULL DEFAULT 500;
+ALTER TABLE character_template ADD COLUMN base_gem_cost INTEGER NOT NULL DEFAULT 50;
+
+-- Add tracking for offline catch-up math
+ALTER TABLE player_profile ADD COLUMN last_tavern_check_time TIMESTAMP WITH TIME ZONE;
+
+-- Create the dedicated Recruitment Pool to manage who can appear
+CREATE TABLE recruitment_pool (
+                                  id UUID PRIMARY KEY,
+                                  character_template_id UUID NOT NULL REFERENCES character_template(id),
+                                  weight INTEGER NOT NULL DEFAULT 10
+);
+
+-- Create the Tavern Listing to track who is currently waiting for a player
+CREATE TABLE tavern_listing (
+                                id UUID PRIMARY KEY,
+                                profile_id UUID NOT NULL UNIQUE REFERENCES player_profile(id),
+                                character_template_id UUID NOT NULL REFERENCES character_template(id),
+                                arrival_time TIMESTAMP WITH TIME ZONE NOT NULL,
+                                expiry_time TIMESTAMP WITH TIME ZONE NOT NULL,
+                                gold_cost INTEGER NOT NULL,
+                                gem_cost INTEGER NOT NULL
+);


### PR DESCRIPTION
- Injected 'TavernService' into 'PlayerController' and invoked 'processArrivals' within the '/me' endpoint, acting as the lazy-check for offline players.
- Refactored 'generateNewListing' in 'TavernService' to return void, removing the unused assignment warning since the loop breaks immediately upon hero arrival.
- Modernized list access in 'TavernService' by replacing 'pool.get(pool.size() - 1)' with Java 21's 'pool.getLast()'."