### PR TITLE
feat: implement Keep storage vault and fix Tavern seeding/UI formatting

### DIFF
--- a/dreamreach-ui/src/components/BuildingSidePanel.tsx
+++ b/dreamreach-ui/src/components/BuildingSidePanel.tsx
@@ -288,6 +288,10 @@ export default function BuildingSidePanel({
                             <button className="button" style={{ width: '100%', padding: '12px' }} onClick={() => onSelectInstance(selectedGroup.instances[0])}>
                                 Enter the Tavern
                             </button>
+                        ) : selectedGroup.instances.length === 1 && selectedGroup.type === 'keep' ? (
+                            <button className="button" style={{ width: '100%', padding: '12px' }} onClick={() => onSelectInstance(selectedGroup.instances[0])}>
+                                View Vault Logistics
+                            </button>
                         ) : (
                             selectedGroup.instances.map((instance, index) => (
                                 <div key={instance.id} className="instance-item" onClick={() => onSelectInstance(instance)}>
@@ -338,7 +342,29 @@ export default function BuildingSidePanel({
 
             {displayInstance && (
                 <>
-                    {selectedGroup.type === 'tavern' ? (
+                    {selectedGroup.type === 'keep' ? (
+                        <div className="panel" style={{ background: 'var(--bg-elevated)', marginTop: 'var(--space-md)' }}>
+                            <h4 style={{ fontSize: '0.8rem', marginBottom: 'var(--space-md)', color: 'var(--text-muted)' }}>VAULT STORAGE</h4>
+                            <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+                                {[
+                                    { label: 'Food', current: profile.food, color: 'var(--success)' },
+                                    { label: 'Wood', current: profile.wood, color: '#cd853f' },
+                                    { label: 'Stone', current: profile.stone, color: 'var(--text-muted)' },
+                                    { label: 'Gold', current: profile.gold, color: 'var(--accent-gold)' }
+                                ].map(res => (
+                                    <div key={res.label}>
+                                        <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '0.85rem', marginBottom: '4px' }}>
+                                            <span>{res.label}</span>
+                                            <span><span style={{ color: res.current >= profile.maxStorage ? 'var(--danger)' : 'inherit' }}>{res.current}</span> / {profile.maxStorage}</span>
+                                        </div>
+                                        <div className="progress-bar-container" style={{ height: '6px', background: 'var(--surface-2)' }}>
+                                            <div className="progress-bar-fill" style={{ width: `${Math.min(100, (res.current / profile.maxStorage) * 100)}%`, background: res.color }}></div>
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                    ) : selectedGroup.type === 'tavern' ? (
                         renderTavernInterior()
                     ) : isHouse ? (
                         <div className="panel" style={{ background: 'var(--bg-elevated)', marginTop: 'var(--space-md)' }}>

--- a/dreamreach-ui/src/views/KingdomView.tsx
+++ b/dreamreach-ui/src/views/KingdomView.tsx
@@ -75,6 +75,7 @@ export interface PlayerProfile {
     lastTaxCollectionTimeEpoch: number;
 
     keepLevel: number;
+    maxStorage: number;
     houses: number;
     towers: number;
     bakeries: number;

--- a/src/main/java/com/keves/dreamreach/config/GameEconomyConfig.java
+++ b/src/main/java/com/keves/dreamreach/config/GameEconomyConfig.java
@@ -28,6 +28,9 @@ public class GameEconomyConfig {
     private int startingBakeries = 0;
     private int startingLodges = 0;
 
+    // --- RESOURCE STORAGE ---
+    private int baseStoragePerKeepLevel = 500;
+
     // --- PASSIVE BASELINE ---
     private int basePassiveWood = 30;
     private int basePassiveStone = 30;

--- a/src/main/java/com/keves/dreamreach/controller/PlayerController.java
+++ b/src/main/java/com/keves/dreamreach/controller/PlayerController.java
@@ -2,6 +2,7 @@ package com.keves.dreamreach.controller;
 
 import com.keves.dreamreach.config.GameEconomyConfig;
 import com.keves.dreamreach.dto.*;
+import com.keves.dreamreach.entity.BuildingInstance;
 import com.keves.dreamreach.entity.PlayerAccount;
 import com.keves.dreamreach.entity.PlayerProfile;
 import com.keves.dreamreach.entity.PlayerPopulation;
@@ -62,6 +63,14 @@ public class PlayerController {
         tavernService.processArrivals(profile);
 
         PlayerPopulation pop = profile.getPopulation();
+
+        // Calculate actual keep level
+        int keepLevel = profile.getBuildings().stream()
+                .filter(b -> b.getBuildingType().equalsIgnoreCase("keep"))
+                .mapToInt(BuildingInstance::getLevel)
+                .max().orElse(1);
+
+        int maxStorage = keepLevel * economyConfig.getBaseStoragePerKeepLevel();
 
         int houseCount = (int) profile.getBuildings().stream()
                 .filter(b -> b.getBuildingType().equalsIgnoreCase("house")).count();
@@ -192,7 +201,8 @@ public class PlayerController {
                 .hunters(pop != null ? pop.getHunters() : 0)
                 .bakers(pop != null ? pop.getBakers() : 0)
 
-                .keepLevel(1)
+                .keepLevel(keepLevel)
+                .maxStorage(maxStorage)
                 .houses(houseCount)
                 .towers((int) profile.getBuildings().stream().filter(b -> b.getBuildingType().equalsIgnoreCase("tower")).count())
                 .bakeries((int) profile.getBuildings().stream().filter(b -> b.getBuildingType().equalsIgnoreCase("bakery")).count())

--- a/src/main/java/com/keves/dreamreach/dto/PlayerProfileResponse.java
+++ b/src/main/java/com/keves/dreamreach/dto/PlayerProfileResponse.java
@@ -55,6 +55,7 @@ public class PlayerProfileResponse {
 
     // Structure Data
     private int keepLevel;
+    private int maxStorage;
     private int houses;
     private int towers;
     private int bakeries;


### PR DESCRIPTION
- Backend (Seeder): Refactored DataSeeder to use a find-or-create pattern for Character Templates, preventing unique constraint violations on existing databases and removing dummy account generation.
- Backend (Economy): Introduced 'baseStoragePerKeepLevel' to GameEconomyConfig and implemented 'maxStorage' calculations in the PlayerController based on the user's true Keep level.
- Frontend (Keep): Built the Vault Logistics UI in the BuildingSidePanel to visualize current vs. max resource capacities with color-coded progress bars.
- Frontend (HUD): Added the user's Gem balance to the global navigation header next to Gold.
- Frontend (UX): Updated 'formatTimeRemaining' helpers to dynamically convert long durations (like the 48-hour Tavern expiry) into readable hours and minutes instead of endlessly stacking minutes."