### PR TITLE
fix: prevent population loss and duplication exploit during citizen t…

### DIFF
--- a/src/main/java/com/keves/dreamreach/config/GameEconomyConfig.java
+++ b/src/main/java/com/keves/dreamreach/config/GameEconomyConfig.java
@@ -15,9 +15,9 @@ public class GameEconomyConfig {
 
     // --- STARTING CONDITIONS ---
     private int startingFood = 150;
-    private int startingWood = 100;
-    private int startingStone = 50;
-    private int startingGold = 0;
+    private int startingWood = 150;
+    private int startingStone = 100;
+    private int startingGold = 20;
     private int startingGems = 0;
 
     private int startingHappiness = 50;

--- a/src/main/java/com/keves/dreamreach/entity/PlayerPopulation.java
+++ b/src/main/java/com/keves/dreamreach/entity/PlayerPopulation.java
@@ -17,6 +17,8 @@ public class PlayerPopulation {
     @Column(nullable = false) private int happiness = 50;
 
     @Column(nullable = false) private int idlePeasants = 0;
+    @Column(nullable = false) private int inTraining = 0;
+
     @Column(nullable = false) private int hunters = 0;
     @Column(nullable = false) private int woodcutters = 0;
     @Column(nullable = false) private int stoneworkers = 0;
@@ -31,6 +33,6 @@ public class PlayerPopulation {
     private PlayerProfile profile;
 
     public int getTotalPopulation() {
-        return idlePeasants + hunters + woodcutters + stoneworkers + bakers;
+        return idlePeasants + inTraining + hunters + woodcutters + stoneworkers + bakers;
     }
 }

--- a/src/main/java/com/keves/dreamreach/service/TrainingService.java
+++ b/src/main/java/com/keves/dreamreach/service/TrainingService.java
@@ -87,10 +87,11 @@ public class TrainingService {
             throw new IllegalStateException("Not enough resources to train these peasants.");
         }
 
-        // 3. Deduct resources and immediately remove the peasants from the 'Idle' pool
+        // 3. Deduct resources and shift the peasants from 'Idle' to 'In Training'
         res.setGold(res.getGold() - totalGoldCost);
         res.setFood(res.getFood() - totalFoodCost);
         pop.setIdlePeasants(pop.getIdlePeasants() - quantity);
+        pop.setInTraining(pop.getInTraining() + quantity);
 
         // 4. Sequential Queuing Logic: Find the latest completion time of existing tasks
         List<TrainingTask> existingTasks = taskRepository.findByProfileIdOrderByStartTimeAsc(profile.getId());
@@ -137,6 +138,11 @@ public class TrainingService {
         }
 
         PlayerPopulation pop = profile.getPopulation();
+
+        // Safety check to ensure we don't drop below zero if something desynced
+        if (pop.getInTraining() > 0) {
+            pop.setInTraining(pop.getInTraining() - 1);
+        }
 
         // Physically convert the unit into its new profession
         switch (task.getProfessionType().toLowerCase()) {

--- a/src/main/resources/db/migration/V16__Add_In_Training_Count.sql
+++ b/src/main/resources/db/migration/V16__Add_In_Training_Count.sql
@@ -1,0 +1,1 @@
+ALTER TABLE player_population ADD COLUMN in_training INT NOT NULL DEFAULT 0;


### PR DESCRIPTION
…raining

- Database: Added V16 Flyway migration to introduce an 'in_training' column to the 'player_population' table.
- Entity: Updated 'PlayerPopulation.java' to track the new 'inTraining' state and included it in the 'getTotalPopulation()' calculation, preventing the HUD population counter from dropping when training starts.
- Service: Refactored 'TrainingService.java' to correctly shift peasants from 'Idle' to 'In Training', and finally to their specific profession upon completion. This plugs the population leak that was tricking the 'EconomyService' into spawning redundant replacement citizens."