### PR TITLE
feat: implement centralized account deletion protocol and fix roster …

### DIFF
--- a/src/main/java/com/keves/dreamreach/controller/AdminController.java
+++ b/src/main/java/com/keves/dreamreach/controller/AdminController.java
@@ -1,0 +1,45 @@
+package com.keves.dreamreach.controller;
+
+import com.keves.dreamreach.entity.PlayerAccount;
+import com.keves.dreamreach.exception.ResourceNotFoundException;
+import com.keves.dreamreach.repository.PlayerAccountRepository;
+import com.keves.dreamreach.service.AccountCleanupService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * Secure endpoints for authorized game administrators.
+ */
+@RestController
+@RequestMapping("/api/admin")
+public class AdminController {
+
+    private final PlayerAccountRepository accountRepository;
+    private final AccountCleanupService cleanupService;
+
+    public AdminController(PlayerAccountRepository accountRepository, AccountCleanupService cleanupService) {
+        this.accountRepository = accountRepository;
+        this.cleanupService = cleanupService;
+    }
+
+    /**
+     * Allows an administrator to permanently delete any player's account and kingdom data.
+     */
+    @DeleteMapping("/accounts/{email}")
+    public ResponseEntity<?> deleteAccount(@PathVariable String email, Authentication authentication) {
+        PlayerAccount requestingAdmin = accountRepository.findByEmail(authentication.getName())
+                .orElseThrow(() -> new ResourceNotFoundException("Admin account not found."));
+
+        if (!requestingAdmin.isAdmin()) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body("Admin privileges required.");
+        }
+
+        PlayerAccount targetAccount = accountRepository.findByEmail(email)
+                .orElseThrow(() -> new ResourceNotFoundException("Target account not found."));
+
+        cleanupService.deleteAccountAndAllRelationalData(targetAccount);
+        return ResponseEntity.ok("Account " + email + " successfully deleted.");
+    }
+}

--- a/src/main/java/com/keves/dreamreach/controller/PlayerController.java
+++ b/src/main/java/com/keves/dreamreach/controller/PlayerController.java
@@ -10,10 +10,12 @@ import com.keves.dreamreach.exception.ResourceNotFoundException;
 import com.keves.dreamreach.repository.ConstructionTaskRepository;
 import com.keves.dreamreach.repository.PlayerAccountRepository;
 import com.keves.dreamreach.repository.TrainingTaskRepository;
+import com.keves.dreamreach.service.AccountCleanupService;
 import com.keves.dreamreach.service.EconomyService;
 import com.keves.dreamreach.service.TavernService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -34,19 +36,22 @@ public class PlayerController {
     private final ConstructionTaskRepository constructionTaskRepository;
     private final TrainingTaskRepository trainingTaskRepository;
     private final TavernService tavernService;
+    private final AccountCleanupService cleanupService;
 
     public PlayerController(PlayerAccountRepository accountRepository,
                             GameEconomyConfig economyConfig,
                             EconomyService economyService,
                             ConstructionTaskRepository constructionTaskRepository,
                             TrainingTaskRepository trainingTaskRepository,
-                            TavernService tavernService) {
+                            TavernService tavernService,
+                            AccountCleanupService cleanupService) {
         this.accountRepository = accountRepository;
         this.economyConfig = economyConfig;
         this.economyService = economyService;
         this.constructionTaskRepository = constructionTaskRepository;
         this.trainingTaskRepository = trainingTaskRepository;
         this.tavernService = tavernService;
+        this.cleanupService = cleanupService;
     }
 
     @GetMapping("/me")
@@ -58,13 +63,11 @@ public class PlayerController {
 
         PlayerProfile profile = account.getProfile();
 
-        // Run the "lazy checks" to process offline time for the economy and the Tavern
         economyService.updateProductionState(profile);
         tavernService.processArrivals(profile);
 
         PlayerPopulation pop = profile.getPopulation();
 
-        // Calculate actual keep level
         int keepLevel = profile.getBuildings().stream()
                 .filter(b -> b.getBuildingType().equalsIgnoreCase("keep"))
                 .mapToInt(BuildingInstance::getLevel)
@@ -80,7 +83,6 @@ public class PlayerController {
         int woodRate = (pop != null ? pop.getWoodcutters() * economyConfig.getWoodPerWoodcutter() : 0) + economyConfig.getBasePassiveWood();
         int stoneRate = (pop != null ? pop.getStoneworkers() * economyConfig.getStonePerStoneworker() : 0) + economyConfig.getBasePassiveStone();
 
-        // Map real database building instances to Response DTOs
         List<BuildingInstanceResponse> buildingResponses = profile.getBuildings().stream()
                 .map(b -> BuildingInstanceResponse.builder()
                         .id(b.getId())
@@ -216,5 +218,17 @@ public class PlayerController {
                 .build();
 
         return ResponseEntity.ok(response);
+    }
+
+    /**
+     * Irreversibly deletes the authenticated user's account and all associated game data.
+     */
+    @DeleteMapping("/me")
+    public ResponseEntity<?> deleteMyAccount(Authentication authentication) {
+        PlayerAccount account = accountRepository.findByEmail(authentication.getName())
+                .orElseThrow(() -> new ResourceNotFoundException("Account not found."));
+
+        cleanupService.deleteAccountAndAllRelationalData(account);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/keves/dreamreach/entity/PlayerAccount.java
+++ b/src/main/java/com/keves/dreamreach/entity/PlayerAccount.java
@@ -31,6 +31,9 @@ public class PlayerAccount {
     @Column(nullable = false)
     boolean isEnabled = false; // this gets toggled when user verifies email for a new account.
 
+    @Column(nullable = false)
+    private boolean isAdmin = false;
+
     @Column(name = "last_login_date")
     private Instant lastLoginDate;
 

--- a/src/main/java/com/keves/dreamreach/service/AccountCleanupService.java
+++ b/src/main/java/com/keves/dreamreach/service/AccountCleanupService.java
@@ -1,8 +1,9 @@
 package com.keves.dreamreach.service;
 
+import com.keves.dreamreach.entity.PlayerAccount;
+import com.keves.dreamreach.entity.PlayerProfile;
 import com.keves.dreamreach.entity.VerificationToken;
-import com.keves.dreamreach.repository.PlayerAccountRepository;
-import com.keves.dreamreach.repository.VerificationTokenRepository;
+import com.keves.dreamreach.repository.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -11,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 
 @Slf4j
 @Service
@@ -19,6 +21,12 @@ public class AccountCleanupService {
 
     private final VerificationTokenRepository tokenRepository;
     private final PlayerAccountRepository accountRepository;
+
+    // Repositories for orphaned relational data
+    private final PlayerCharacterRepository characterRepository;
+    private final ConstructionTaskRepository constructionRepository;
+    private final TrainingTaskRepository trainingRepository;
+    private final TavernListingRepository tavernRepository;
 
     // Execute at exactly midnight server time every day
     @Scheduled(cron = "0 0 0 * * ?")
@@ -35,11 +43,33 @@ public class AccountCleanupService {
 
         for (VerificationToken token : expiredTokens) {
             log.debug("Reaping unverified account ID: {}", token.getAccount().getId());
-            // Deleting the account triggers the PostgreSQL ON DELETE CASCADE
-            // which automatically deletes the token and profile.
-            accountRepository.delete(token.getAccount());
+            deleteAccountAndAllRelationalData(token.getAccount());
         }
 
         log.info("Daily Sweep complete. Purged {} unverified accounts from the server.", expiredTokens.size());
+    }
+
+    /**
+     * Helper function to completely eradicate an account and all associated entities.
+     * Prevents Foreign Key Constraint violations from loose tables.
+     */
+    @Transactional
+    public void deleteAccountAndAllRelationalData(PlayerAccount account) {
+        PlayerProfile profile = account.getProfile();
+
+        if (profile != null) {
+            UUID profileId = profile.getId();
+
+            // 1. Manually wipe out tables that do not have CascadeType.ALL mapped in PlayerProfile
+            tavernRepository.deleteAll(tavernRepository.findByProfileId(profileId).stream().toList());
+            trainingRepository.deleteAll(trainingRepository.findByProfileIdOrderByStartTimeAsc(profileId));
+            constructionRepository.deleteAll(constructionRepository.findByProfileId(profileId));
+            characterRepository.deleteAll(characterRepository.findByOwnerId(profileId));
+        }
+
+        // 2. Delete the root account.
+        // This triggers the JPA CascadeType.ALL to wipe the Profile, Buildings, Resources, and Population.
+        accountRepository.delete(account);
+        log.info("Successfully wiped account: {}", account.getEmail());
     }
 }


### PR DESCRIPTION
…queries

- Bugfix (Roster): Updated RosterController to map to the root '/api/roster' endpoint and utilize JWT authentication, resolving the 404 error caused by missing path variables in the frontend request.
- Feature (Data Integrity): Created 'AccountCleanupService' to orchestrate safe cascading deletions, manually sweeping orphaned relational data (characters, tavern listings, tasks) prior to tearing down the root account.
- Feature (Self-Service): Added 'DELETE /api/player/me' endpoint allowing authenticated users to permanently close their own accounts.
- Feature (Admin Tools): Added 'isAdmin' boolean to 'PlayerAccount' entity and built a secure 'AdminController' to allow privileged users to manage and delete target accounts, resolving technical debt without relying on manual database scripts."