### PR TITLE
restore Layout logic and define semantic CSS variables for storage bars

### DIFF
--- a/dreamreach-ui/src/App.css
+++ b/dreamreach-ui/src/App.css
@@ -21,6 +21,11 @@
   --font-body: 'Inter', sans-serif;
 }
 
+/* Semantic Aliases for vault bars */
+--success: var(--accent-green);
+--danger: var(--accent-red);
+--warning: var(--accent-gold);
+
 body {
   margin: 0;
   background-color: var(--bg-main);

--- a/dreamreach-ui/src/components/Layout.tsx
+++ b/dreamreach-ui/src/components/Layout.tsx
@@ -44,6 +44,11 @@ export default function Layout() {
                 const stonePerSec = (prevProfile.stoneRate || 0) / 3600;
                 const foodPerSec = (prevProfile.foodRate || 0) / 3600;
 
+                // Sync the production state with the original accumulator reference
+                accumulatorRef.current.wood += woodPerSec * dtSeconds;
+                accumulatorRef.current.stone += stonePerSec * dtSeconds;
+                accumulatorRef.current.food += foodPerSec * dtSeconds;
+
                 // We allow the pending values in state to hold decimals.
                 // This allows the Keep progress bars to update smoothly in real-time.
                 const newPendingWood = prevProfile.pendingWood + (woodPerSec * dtSeconds);


### PR DESCRIPTION
- CSS: Defined --success, --danger, and --warning semantic aliases in App.css to correctly color the Keep Vault progress bars.
- Frontend: Restored the original 'accumulatorRef' logic and structure in Layout.tsx while allowing decimal state updates to ensure smooth real-time visual movement in the progress bars."