### PR TITLE
feat(roster): implement Short and Long Rest recovery engine

### DIFF
--- a/src/main/java/com/keves/dreamreach/controller/RosterController.java
+++ b/src/main/java/com/keves/dreamreach/controller/RosterController.java
@@ -8,10 +8,13 @@ import com.keves.dreamreach.service.PlayerCharacterService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.UUID;
 
 /**
  * Handles incoming HTTP requests for player roster data.
@@ -40,8 +43,21 @@ public class RosterController {
                 .orElseThrow(() -> new ResourceNotFoundException("Account not found."));
 
         // Fetch the roster using the display name tied to their authenticated profile
+        // This implicitly calculates all passive short/long rest recovery logic
         List<CharacterRosterResponse> roster = playerCharacterService.getPlayerRoster(account.getProfile().getDisplayName());
 
         return ResponseEntity.ok(roster);
+    }
+
+    /**
+     * Initiates a Long Rest for a specific character.
+     */
+    @PostMapping("/{characterId}/rest")
+    public ResponseEntity<?> initiateLongRest(@PathVariable UUID characterId, Authentication authentication) {
+        PlayerAccount account = accountRepository.findByEmail(authentication.getName())
+                .orElseThrow(() -> new ResourceNotFoundException("Account not found."));
+
+        playerCharacterService.initiateLongRest(characterId, account.getProfile().getDisplayName());
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/keves/dreamreach/service/PlayerCharacterService.java
+++ b/src/main/java/com/keves/dreamreach/service/PlayerCharacterService.java
@@ -10,7 +10,10 @@ import com.keves.dreamreach.util.DndMathUtility;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.stereotype.Service;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
@@ -24,16 +27,95 @@ public class PlayerCharacterService {
         this.playerProfileRepository = playerProfileRepository;
     }
 
-    @Transactional(readOnly = true)
+    @Transactional // Removed readOnly = true to allow state updates on fetch
     public List<CharacterRosterResponse> getPlayerRoster(String displayName) {
         PlayerProfile player = playerProfileRepository.findByDisplayName(displayName)
                 .orElseThrow(() -> new ResourceNotFoundException("Player profile not found for display name: " + displayName));
+
+        // Process resting logic before sending the roster back to the UI
+        processPassiveRecovery(player);
 
         List<PlayerCharacter> rawRoster = playerCharacterRepository.findByOwnerId(player.getId());
 
         return rawRoster.stream()
                 .map(this::mapToRosterResponse)
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Processes passive Short Rest healing and Long Rest completion.
+     */
+    @Transactional
+    public void processPassiveRecovery(PlayerProfile profile) {
+        List<PlayerCharacter> roster = playerCharacterRepository.findByOwnerId(profile.getId());
+        Instant now = Instant.now();
+
+        for (PlayerCharacter hero : roster) {
+            boolean updated = false;
+
+            // Process Long Rest completion
+            if ("RESTING".equalsIgnoreCase(hero.getStatus()) && hero.getLongRestEndTime() != null) {
+                if (now.isAfter(hero.getLongRestEndTime())) {
+                    hero.setStatus("IDLE");
+                    hero.setCurrentHp(hero.getMaxHp());
+                    hero.setCurrentMana(hero.getMaxMana());
+                    hero.setSpentHitDice(0); // Recover all spent Hit Dice
+                    hero.setLongRestEndTime(null);
+                    hero.setLastRestTick(now);
+                    updated = true;
+                }
+            }
+
+            // Process Passive Short Rest (Idle Healing)
+            if ("IDLE".equalsIgnoreCase(hero.getStatus()) && hero.getLastRestTick() != null) {
+                long hoursElapsed = ChronoUnit.HOURS.between(hero.getLastRestTick(), now);
+                if (hoursElapsed > 0) {
+                    for (int i = 0; i < hoursElapsed; i++) {
+                        if (hero.getCurrentHp() < hero.getMaxHp() && hero.getSpentHitDice() < hero.getMaxHitDice()) {
+                            hero.setSpentHitDice(hero.getSpentHitDice() + 1);
+
+                            // Average Hit Die Value = (Max / 2) + 1
+                            int avgHitDie = (hero.getTemplate().getHitDieType() / 2) + 1;
+                            int conMod = DndMathUtility.calculateModifier(hero.getTotalConstitution());
+                            int healAmount = Math.max(1, avgHitDie + conMod); // At least 1 HP
+
+                            hero.setCurrentHp(Math.min(hero.getMaxHp(), hero.getCurrentHp() + healAmount));
+                        }
+                    }
+                    // Only advance the tick by the exact full hours processed, retaining the fractional minutes
+                    hero.setLastRestTick(hero.getLastRestTick().plus(hoursElapsed, ChronoUnit.HOURS));
+                    updated = true;
+                }
+            }
+
+            if (updated) {
+                playerCharacterRepository.save(hero);
+            }
+        }
+    }
+
+    /**
+     * Initiates an 8-hour Long Rest for the specified character.
+     */
+    @Transactional
+    public void initiateLongRest(UUID characterId, String displayName) {
+        PlayerProfile player = playerProfileRepository.findByDisplayName(displayName)
+                .orElseThrow(() -> new ResourceNotFoundException("Player profile not found for display name: " + displayName));
+
+        PlayerCharacter hero = playerCharacterRepository.findById(characterId)
+                .orElseThrow(() -> new ResourceNotFoundException("Character not found."));
+
+        if (!hero.getOwner().getId().equals(player.getId())) {
+            throw new IllegalArgumentException("You do not own this character.");
+        }
+
+        if (!"IDLE".equalsIgnoreCase(hero.getStatus()) && !"KO".equalsIgnoreCase(hero.getStatus())) {
+            throw new IllegalStateException("Character must be IDLE or KO to initiate a Long Rest.");
+        }
+
+        hero.setStatus("RESTING");
+        hero.setLongRestEndTime(Instant.now().plus(8, ChronoUnit.HOURS));
+        playerCharacterRepository.save(hero);
     }
 
     /**


### PR DESCRIPTION
- Backend (Service): Updated PlayerCharacterService to perform lazy-evaluation of passive Short Rest healing (1 HD per hour) when the roster is fetched.
- Backend (Service): Added initiateLongRest logic to lock a character for 8 hours, fully restoring HP, Mana, and Hit Dice upon completion.
- Backend (Controller): Exposed POST /api/roster/{characterId}/rest endpoint to trigger active Long Rests.
- Backend (Controller): Updated getMyRoster to trigger the processPassiveRecovery cycle before returning state to the frontend.